### PR TITLE
Add the missing jul-to-slf4j dependency

### DIFF
--- a/Getting-Started-IDEA-Gradle.md
+++ b/Getting-Started-IDEA-Gradle.md
@@ -232,6 +232,7 @@ We can set up logging to remove these warning messages and get a better idea of 
 Add the following to the gradle dependencies:
     
 ```
+    compile "org.slf4j:jul-to-slf4j:1.7.12"
     compile "ch.qos.logback:logback-classic:1.2.1"
 ```
     


### PR DESCRIPTION
The error `SLF4J: Failed to load class "org.slf4j.impl.StaticLoggerBinder"` still shows up without this dependency.