### PR TITLE
Fix the link to Getting Started IDEA Gradle

### DIFF
--- a/Getting-Started.md
+++ b/Getting-Started.md
@@ -59,4 +59,4 @@ Given that the entry point to our application is a the standard Kotlin `main` fu
 
 This was the simplest example of getting a self-hosted Ktor application up and running. Next steps will be to understand the [Application](Application) object as well as [Features](Features).
 
-For a more detailed Getting Started example see [Getting Started with IDEA and Gradle](Getting-Started-IDEA-Gradle.md)
+For a more detailed Getting Started example see [Getting Started with IDEA and Gradle](Getting-Started-IDEA-Gradle)


### PR DESCRIPTION
Right now the link shows the raw markdown. This fix will link to the wiki-rendered version of the page.